### PR TITLE
Styling adjustments

### DIFF
--- a/css/gis_ia.css
+++ b/css/gis_ia.css
@@ -46,8 +46,8 @@
 .gis_ia_filters_arrow_down::before {border-style: solid;border-width: 0.15em 0.15em 0 0;content: '';display: inline-block;height: 0.45em;left: 0.15em;position: relative;top: 0.15em;transform: rotate(-45deg);vertical-align: top;width: 0.45em;top: 0;transform: rotate(135deg);pointer-events:none;}
 .gis_ia_arrow_down_has_x {right: 38px;}
 /* filter X buttons */
-.gis_ia_filters .gis_ia_f_f_xx {cursor: pointer;text-decoration: none; border: none;}
-.gis_ia_filters .gis_ia_f_f_xx:before {content: "\00d7"; display: inline-block; width: 29px; vertical-align: top; padding-left: 3px;}
+.gis_ia_filters .gis_ia_f_f_xx {cursor: pointer;text-decoration: none; border: none;display: block; margin-bottom: 0.5em;}
+.gis_ia_filters .gis_ia_f_f_xx:before {content: "\00d7"; display: inline-block; width: 29px; vertical-align: top; padding-left: 3px; font-size: 1.5rem; line-height: 1;}
 .gis_ia_filters .gis_ia_f_f_xx span {display: inline-block; max-width: calc(100% - 37px); word-break: break-all;}
 .gis_ia_filters .gis_ia_f_f_x_simple .gis_ia_f_f_xx:before {width: 16px !important;}
 .gis_ia_filters .gis_ia_f_f_x_simple {float: right; text-align: right;}

--- a/js/gis_ia.js
+++ b/js/gis_ia.js
@@ -1442,6 +1442,8 @@ function gis_ia_filterwindowCheck(map_id) {
       gis_ia_filterwindowCheckHide(map_id);
       jQuery('#gis_ia_map_' + map_id).parent().parent().css('width','100%');
       jQuery('#gis_ia_filters_' + map_id).addClass('gis_ia_as_slider').parent().css('width',0);
+      jQuery('#f1b-' + map_id).show();
+      jQuery('#f2-' + map_id).hide();
       base.removeClass('gis_ia_as_block').addClass('gis_ia_as_slider');
       // zet max-heigth van filterblok
       jQuery('#gis_ia_filters_' + map_id).css('max-height', jQuery('#gis_ia_map_' + map_id).css('max-height') + 'px');


### PR DESCRIPTION
2 aanpassingen voor de GIS-viewer doorgevoerd: 
- In het filterpaneel heb ik de kruisjes wat groter gemaakt en heb ik de geselecteerde items een margin-bottom gegeven waardoor de interlinie met de overige items gelijkt blijft.
- Als er werd geswitched van fullscreen naar gewone weergave was de sluitknop en de opties knop in de kaart niet zichtbaar. Dit is aangepast.